### PR TITLE
Make either drinkId or coverId required

### DIFF
--- a/app/Http/Controllers/Api/DrinkController.php
+++ b/app/Http/Controllers/Api/DrinkController.php
@@ -66,11 +66,11 @@ class DrinkController extends ResponseController
     {
         $validator = Validator::make($request->all(), [
             'friendId' => 'exists:users,id', // Not sure what do, is it for gift to friend?
-            'locationId' => 'required|exists:locations,id',
-            'drinkId' => 'exists:drinks,id',
-            'coverId' => 'exists:covers,id',
+            'locationId' => 'exists:locations,id',
+            'drinkId' => 'required_without:coverId',
+            'coverId' => 'required_without:drinkId',
             'quantity' => 'required|numeric',
-            'message'  => 'required'
+            'message'  => ''
         ]);
 
         if ($validator->fails()) {


### PR DESCRIPTION
@whittakergroupinc 
It seems the requirements for drinkId and coverId should be either or instead of both.